### PR TITLE
feat: Added automerge_level option

### DIFF
--- a/MaliniAeria/Decorators/WithAeria.php
+++ b/MaliniAeria/Decorators/WithAeria.php
@@ -14,16 +14,31 @@ class WithAeria extends PostDecorator implements PostDecoratorInterface
         $wp_post = $post->wp_post;
 
         $aeria_automerge_fields = $this->getConfig('automerge_fields', $options, false);
+        $aeria_automerge_level = $this->getConfig('automerge_level', $options, 1);
+
+        // accept only 1 or 2
+        $aeria_automerge_level = max(1, min(2, $aeria_automerge_level));
 
         if ($aeria_automerge_fields) {
+            $post_fields = AeriaAccessor::getPostFields($wp_post);
             $fields_keys = array_keys(
-                AeriaAccessor::getPostFields($wp_post)
+                $post_fields
             );
+
             foreach ($fields_keys as $key) {
-                $post->addAttribute(
-                    $key,
-                    '@aeria:' . $key
-                );
+                if ($aeria_automerge_level == 2) {
+                    foreach ($post_fields[$key] as $sub_key => $_element) {
+                        $post->addAttribute(
+                            $sub_key,
+                            '@aeria:' . $key . ',' . $sub_key
+                        );
+                    }
+                } else {
+                    $post->addAttribute(
+                        $key,
+                        '@aeria:' . $key
+                    );
+                }
             }
             $this->filterConfig(
                 $post,


### PR DESCRIPTION
Added `automerge_level` option (min 1, max 2, default 1).
This way we can bubble-up aeria meta fields without having 'em grouped inside the metaboxes keys.